### PR TITLE
Feature/debug dnd

### DIFF
--- a/src/main/java/data/Database.java
+++ b/src/main/java/data/Database.java
@@ -941,6 +941,8 @@ public class Database implements AdminStorage
 
 	public void resetDatabase()
 	{
+		nodeCache.clear();
+
 		runScript(DB_DROP_ALL);
 		runScript(DB_CREATE_SQL);
 		runScript(DB_INSERT_NODES);

--- a/src/main/java/ui/BaseController.java
+++ b/src/main/java/ui/BaseController.java
@@ -12,7 +12,7 @@ import java.io.IOException;
  */
 abstract class BaseController
 {
-	private static Stage stage;
+	protected static Stage stage;
 	private boolean currentSceneSupportsHC = true;
 	private String[] highContrastBlackList = {Paths.LOGIN_FXML, Paths.DIRECTORY_FXML, Paths.DIRECTORY2_FXML};
 	protected static Database database;

--- a/src/main/java/ui/MapEditorToolController.java
+++ b/src/main/java/ui/MapEditorToolController.java
@@ -14,6 +14,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.ContextMenuEvent;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.*;
 import javafx.scene.paint.Color;
@@ -99,7 +100,14 @@ public class MapEditorToolController extends BaseController
 			{
 				if(currentButton != e.getSource() && currentButton != null)
 				{
+					System.out.println("dont happen");
 					currentButton.setId("node-button-unselected");
+					currentButton = (Button)e.getSource();
+					currentButton.setId("node-button-selected");
+					currentNode = nodeButtonLinks.get(currentButton);
+				}
+				else if (currentButton == null)
+				{
 					currentButton = (Button)e.getSource();
 					currentButton.setId("node-button-selected");
 					currentNode = nodeButtonLinks.get(currentButton);
@@ -265,6 +273,25 @@ public class MapEditorToolController extends BaseController
 	 */
 	private void setupImageEventHandlers()
 	{
+		//if esc key is pressed, remove contextmenus/canvases and set state to doingnothing
+		//this is a failsafe as well as feature
+		stage.getScene().setOnKeyPressed(e ->{
+			if(e.getCode() == KeyCode.ESCAPE)
+			{
+				//remove canvas if it exists
+				if (editingFloor.getChildren().contains(canvas))
+				{
+					editingFloor.getChildren().remove(canvas);
+				}
+				//remove context menu if it exists
+				if(editingFloor.getChildren().contains(CONTEXTMENU))
+				{
+					editingFloor.getChildren().remove(CONTEXTMENU);
+				}
+				currentState = editorStates.DOINGNOTHING;
+			}
+		});
+
 		//set the imaveview objects to use the correct images
 		hallwayImage.setImage(Paths.hallwayImageProxy.getFXImage());
 		officeImage.setImage(Paths.doctorImageProxy.getFXImage());
@@ -592,7 +619,6 @@ public class MapEditorToolController extends BaseController
 	 */
 	@FXML
 	void rightclickFloorImage(ContextMenuEvent event) {
-		System.out.println("fuckinghas;dflkj");
 		currentState = editorStates.DOINGNOTHING;
 	}
 
@@ -618,7 +644,7 @@ public class MapEditorToolController extends BaseController
 				database.updateNode(currentNode);
 
 				//draw connecting lines
-				drawToNeighbors(currentNode);
+				//drawToNeighbors(currentNode);
 				drawToNeighbors(oldNode);
 
 				break;
@@ -756,7 +782,8 @@ public class MapEditorToolController extends BaseController
 
 	//TODO: update to match refactored database
 	/**
-	 * Create a new node at given xy coordinates
+	 * Create a new node at given xy coordinates.
+	 * Note on node types: 0 is hallway, 1 is doctorsoffice, 2 is elevator, 3 is resetroom
 	 * @param x X coordinate of new node
 	 * @param y Y coordinate of new node
 	 */
@@ -764,7 +791,6 @@ public class MapEditorToolController extends BaseController
 	{
 		Node newNode = new ConcreteNode();
 		newNode.setName("New " + type);
-		//TODO: Set node type! It's -1 by default!
 		newNode.setX(x);
 		newNode.setY(y);
 		newNode.setFloor(FLOORID);

--- a/src/main/java/ui/MapEditorToolController.java
+++ b/src/main/java/ui/MapEditorToolController.java
@@ -97,6 +97,13 @@ public class MapEditorToolController extends BaseController
 		{
 			if(e.isSecondaryButtonDown())
 			{
+				if(currentButton != e.getSource() && currentButton != null)
+				{
+					currentButton.setId("node-button-unselected");
+					currentButton = (Button)e.getSource();
+					currentButton.setId("node-button-selected");
+					currentNode = nodeButtonLinks.get(currentButton);
+				}
 				currentState = editorStates.SHOWINGNODEMENU;
 				displayContextMenu(e);
 			}

--- a/src/main/resources/db/DBDropAll.sql
+++ b/src/main/resources/db/DBDropAll.sql
@@ -1,9 +1,10 @@
 --This file isn't mean to be used in-program, it's a utility file for database testing in case a failed test left the
 --database in a bad state.
+
+DROP TABLE Buildings;
 DROP TABLE DoctorOffices;
 DROP TABLE Providers;
 DROP TABLE Edges;
 DROP TABLE Services;
 DROP TABLE Nodes;
-DROP TABLE Buildings;
 DROP TABLE Logins;


### PR DESCRIPTION
Fix context menu glitch. The main bug was caused when the node-specific context menu was called when no currentNode was set.
Implement "Esc" keypress in the map editor to set current state to doing nothing (e.g. adding neighbor visuals/state will be canceled, chain adding will be canceled, etc). This simply works by pressing the esc key.

This should fix the bug in issue #42 