### PR TITLE
Feature/refactor visitor view

### DIFF
--- a/src/main/java/ui/controller/MapEditorToolController.java
+++ b/src/main/java/ui/controller/MapEditorToolController.java
@@ -147,13 +147,20 @@ public class MapEditorToolController extends BaseController
 				final double scale = calculateScale(scrollEvent);
 				editingFloor.setScaleX(scale);
 				editingFloor.setScaleY(scale);
+				zoomWrapper.setPrefHeight(editingFloor.getHeight()*scale);
+				zoomWrapper.setPrefWidth(editingFloor.getWidth()*scale);
+
 				zoomWrapper.setMinWidth(editingFloor.getWidth()*scale);
 				zoomWrapper.setMinHeight(editingFloor.getHeight()*scale);
 				zoomWrapper.setMaxWidth(editingFloor.getWidth()*scale);
 				zoomWrapper.setMaxHeight(editingFloor.getHeight()*scale);
 
-				editingFloor.setLayoutX((zoomWrapper.getWidth() - editingFloor.getWidth())/2);
-				editingFloor.setLayoutY((zoomWrapper.getHeight() - editingFloor.getHeight())/2);
+
+			System.out.println(zoomWrapper.getWidth());
+			System.out.println(zoomWrapper.getHeight());
+
+				editingFloor.setLayoutX((zoomWrapper.getWidth() - floorImage.getImage().getWidth())/2);
+				editingFloor.setLayoutY((zoomWrapper.getHeight() - floorImage.getImage().getHeight())/2);
 				scrollEvent.consume();
 		}
 
@@ -278,14 +285,20 @@ public class MapEditorToolController extends BaseController
 		//faulkner building
 		if(buildingid.equals("00000000-0000-0000-0000-000000000000"))
 		{
+			floorImage.setFitWidth(Paths.regularFloorImages[floor-1].getFXImage().getWidth());
+			floorImage.setFitHeight(Paths.regularFloorImages[floor-1].getFXImage().getHeight());
 			floorImage.setImage(Paths.regularFloorImages[floor-1].getFXImage());
 		}
 		else if(buildingid.equals("00000000-0000-0000-0000-111111111111"))
 		{
+			floorImage.setFitWidth(Paths.belkinFloorImages[floor-1].getFXImage().getWidth());
+			floorImage.setFitHeight(Paths.belkinFloorImages[floor-1].getFXImage().getHeight());
 			floorImage.setImage(Paths.belkinFloorImages[floor-1].getFXImage());
 		}
 		else if (buildingid.equals("00000000-0000-0000-0000-222222222222"))
 		{
+			floorImage.setFitWidth(Paths.outdoorImageProxy.getFXImage().getWidth());
+			floorImage.setFitHeight(Paths.outdoorImageProxy.getFXImage().getHeight());
 			floorImage.setImage(Paths.outdoorImageProxy.getFXImage());
 		}
 
@@ -294,10 +307,10 @@ public class MapEditorToolController extends BaseController
 		editingFloor.setMaxWidth(floorImage.getFitWidth());
 		editingFloor.setMaxHeight(floorImage.getFitHeight());
 
-		final double scale = 1;
-		currentZoom = scale;
-		editingFloor.setScaleX(scale);
-		editingFloor.setScaleY(scale);
+//		final double scale = 1;
+//		currentZoom = scale;
+//		editingFloor.setScaleX(scale);
+//		editingFloor.setScaleY(scale);
 
 		zoomWrapper.setMinWidth(floorImage.getFitWidth());
 		zoomWrapper.setMinHeight(floorImage.getFitHeight());

--- a/src/main/resources/fxml/Map.fxml
+++ b/src/main/resources/fxml/Map.fxml
@@ -1,53 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.lang.*?>
-<?import javafx.geometry.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.image.*?>
-<?import javafx.scene.layout.*?>
-<?import javafx.scene.text.*?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.Tab?>
+<?import javafx.scene.control.TabPane?>
+<?import javafx.scene.image.Image?>
+<?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.text.Font?>
 
-<SplitPane fx:id="roomviewSplit" centerShape="false" dividerPositions="0.75" pickOnBounds="false" prefHeight="720.0" prefWidth="1280.0" scaleShape="false" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="ui.controller.MapController">
-    <items>
-        <StackPane alignment="TOP_CENTER">
-            <children>
-                <ScrollPane fx:id="scroller" hbarPolicy="ALWAYS" pannable="true" vbarPolicy="ALWAYS" StackPane.alignment="TOP_LEFT">
-                    <content>
-                        <AnchorPane fx:id="zoomWrapper">
-                            <children>
-                                <AnchorPane fx:id="editingFloor" minHeight="0.0" minWidth="0.0">
-                                    <children>
-                                        <ImageView fx:id="floorImage" fitHeight="1300.0" fitWidth="2250.0" mouseTransparent="false" pickOnBounds="true" preserveRatio="true" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="0.0">
-                                            <image>
-                                                <Image url="@/images/floor3.png" />
-                                            </image>
-                                        </ImageView>
-                                    </children>
-                                </AnchorPane>
-                            </children>
+<HBox prefHeight="720.0" prefWidth="1280.0" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="ui.controller.MapController">
+   <children>
+      <Pane prefHeight="720.0" prefWidth="1028.0" styleClass="bh-background-pane">
+         <children>
+              <StackPane alignment="TOP_CENTER" layoutX="23.0" layoutY="100.0" prefHeight="590.0" prefWidth="936.0" />
+                  <Button layoutX="23.0" layoutY="25.0" mnemonicParsing="false" onAction="#showStartup" styleClass="bh-button" text="&lt; Back" />
+            <TabPane fx:id="buildingTabs" layoutX="23.0" layoutY="65.0" prefHeight="625.0" prefWidth="936.0" tabClosingPolicy="UNAVAILABLE">
+              <tabs>
+                <Tab fx:id="faulknerTab" styleClass="bh-button" text="Faulkner Main">
+                  <content>
+                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
+                           <children>
+                                  <ScrollPane fx:id="faulknerScroller" hbarPolicy="ALWAYS" pannable="true" prefHeight="720.0" prefWidth="955.0" vbarPolicy="ALWAYS">
+                                      <content>
+                                          <AnchorPane fx:id="faulknerZoomWrapper">
+                                              <children>
+                                                  <AnchorPane fx:id="faulknerEditingFloor" minHeight="1485.0" minWidth="2475.0">
+                                                      <children>
+                                                          <ImageView fx:id="faulknerFloorImage" fitHeight="1485.0" fitWidth="2475.0" mouseTransparent="false" pickOnBounds="true" preserveRatio="true" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                                   <image>
+                                                      <Image url="@../NewFloors/hospital1.png" />
+                                                   </image></ImageView>
+                                                      </children>
+                                                  </AnchorPane>
+                                              </children>
+                                          </AnchorPane>
+                                      </content>
+                                  </ScrollPane>
+                           </children>
                         </AnchorPane>
+                  </content>
+                </Tab>
+                  <Tab fx:id="outdoorsTab" styleClass="bh-button" text="Outdoors">
+                    <content>
+                      <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
+                           <children>
+                              <ScrollPane fx:id="outdoorsScroller" hbarPolicy="ALWAYS" pannable="true" prefHeight="720.0" prefWidth="955.0" vbarPolicy="ALWAYS">
+                                 <content>
+                                    <AnchorPane fx:id="outdoorsZoomWrapper">
+                                       <children>
+                                          <AnchorPane fx:id="outdoorsEditingFloor" minHeight="0.0" minWidth="0.0">
+                                             <children>
+                                                <ImageView fx:id="outdoorsFloorImage" fitHeight="1485.0" fitWidth="2475.0" mouseTransparent="false" pickOnBounds="true" preserveRatio="true" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                                   <image>
+                                                      <Image url="@../NewFloors/outsideFloor.png" />
+                                                   </image>
+                                                </ImageView>
+                                             </children>
+                                          </AnchorPane>
+                                       </children>
+                                    </AnchorPane>
+                                 </content>
+                              </ScrollPane>
+                           </children></AnchorPane>
                     </content>
-                </ScrollPane>
-                <Pane pickOnBounds="false">
+                  </Tab>
+                <Tab fx:id="belkinTab" styleClass="bh-button" text="Belkin House">
+                  <content>
+                    <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">
+                           <children>
+                              <ScrollPane fx:id="belkinScroller" hbarPolicy="ALWAYS" pannable="true" prefHeight="720.0" prefWidth="955.0" vbarPolicy="ALWAYS">
+                                 <content>
+                                    <AnchorPane fx:id="belkinZoomWrapper">
+                                       <children>
+                                          <AnchorPane fx:id="belkinEditingFloor" minHeight="0.0" minWidth="0.0">
+                                             <children>
+                                                <ImageView fx:id="belkinFloorImage" fitHeight="1485.0" fitWidth="2475.0" mouseTransparent="false" pickOnBounds="true" preserveRatio="true" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                                   <image>
+                                                      <Image url="@../NewFloors/belkin1rsz.png" />
+                                                   </image>
+                                                </ImageView>
+                                             </children>
+                                          </AnchorPane>
+                                       </children>
+                                    </AnchorPane>
+                                 </content>
+                              </ScrollPane>
+                           </children></AnchorPane>
+                  </content>
+                </Tab>
+              </tabs>
+            </TabPane>
+                <Pane layoutX="23.0" layoutY="100.0" pickOnBounds="false" prefHeight="119.0" prefWidth="220.0">
                     <children>
-                        <Button layoutX="14.0" layoutY="7.0" mnemonicParsing="false" onAction="#showStartup" text="&lt; Back" />
-                        <Button fx:id="upFloor" layoutX="14.0" layoutY="74.0" mnemonicParsing="false" onAction="#goUpFloor" />
-                        <Button fx:id="downFloor" layoutX="14.0" layoutY="143.0" mnemonicParsing="false" onAction="#goDownFloor" />
-                        <Label fx:id="currentFloorLabel" layoutX="17.0" layoutY="105.0" text="1">
+                        <Button fx:id="upFloor" layoutX="14.0" layoutY="24.0" mnemonicParsing="false" onAction="#goUpFloor" />
+                        <Button fx:id="downFloor" layoutX="14.0" layoutY="93.0" mnemonicParsing="false" onAction="#goDownFloor" />
+                        <Label fx:id="currentFloorLabel" layoutX="17.0" layoutY="55.0" text="1">
                             <font>
                                 <Font size="26.0" />
                             </font>
                         </Label>
                     </children>
                 </Pane>
-            </children>
-        </StackPane>
+         </children>
+      </Pane>
         <VBox fx:id="roomInfo" alignment="TOP_CENTER" spacing="5.0" styleClass="bh-background-pane">
             <children>
                 <AnchorPane>
-                    <children>
-                        <Button mnemonicParsing="false" onAction="#hideRoomInfo" prefHeight="28.0" prefWidth="65.0" styleClass="bh-button" text="Hide &gt;" AnchorPane.leftAnchor="5.0" AnchorPane.topAnchor="5.0" />
-                    </children>
+               <children>
+                  <Pane prefHeight="23.0" prefWidth="200.0" />
+               </children>
                 </AnchorPane>
                 <Label fx:id="roomName" alignment="CENTER" styleClass="bh-styled-label" text="Room 212" wrapText="true">
                     <font>
@@ -57,7 +125,8 @@
             <Label fx:id="servicesLabel" alignment="CENTER" contentDisplay="CENTER" styleClass="bh-styled-label" text="Services" wrapText="true">
                <font>
                   <Font size="17.0" />
-               </font></Label>
+               </font>
+            </Label>
                 <Button alignment="CENTER" contentDisplay="CENTER" mnemonicParsing="false" onAction="#findDirectionsTo" styleClass="bh-button" text="Find Directions">
                     <VBox.margin>
                         <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
@@ -67,7 +136,8 @@
                     </font>
                     <padding>
                         <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
-                    </padding></Button>
+                    </padding>
+            </Button>
             <StackPane>
                <children>
                       <HBox prefHeight="52.0" prefWidth="315.0">
@@ -93,17 +163,20 @@
                   <Insets left="20.0" right="20.0" />
                </VBox.margin>
             </StackPane>
-                <ScrollPane hbarPolicy="NEVER" prefHeight="344.0" prefWidth="315.0" styleClass="hc-black">
+                <ScrollPane hbarPolicy="NEVER" prefHeight="380.0" prefWidth="294.0" styleClass="hc-black">
                     <content>
                         <Label fx:id="textDirectionsLabel" styleClass="hc-black" wrapText="true" />
                     </content>
                     <VBox.margin>
                         <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
-                    </VBox.margin></ScrollPane>
+                    </VBox.margin>
+            </ScrollPane>
                 <Button mnemonicParsing="false" onAction="#clearPath" prefHeight="36.0" prefWidth="315.0" styleClass="bh-button" text="Clear Path">
                     <VBox.margin>
                         <Insets left="20.0" right="20.0" />
-                    </VBox.margin></Button>
-            </children></VBox>
-    </items>
-</SplitPane>
+                    </VBox.margin>
+            </Button>
+            </children>
+      </VBox>
+   </children>
+</HBox>

--- a/src/main/resources/fxml/Map.fxml
+++ b/src/main/resources/fxml/Map.fxml
@@ -33,7 +33,7 @@
                                               <children>
                                                   <AnchorPane fx:id="faulknerEditingFloor" minHeight="1485.0" minWidth="2475.0">
                                                       <children>
-                                                          <ImageView fx:id="faulknerFloorImage" fitHeight="1485.0" fitWidth="2475.0" mouseTransparent="false" pickOnBounds="true" preserveRatio="true" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                                          <ImageView fx:id="faulknerFloorImage" fitHeight="1485.0" fitWidth="2475.0" mouseTransparent="false" pickOnBounds="true" preserveRatio="true" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="0.0">
                                                    <image>
                                                       <Image url="@../NewFloors/hospital1.png" />
                                                    </image></ImageView>
@@ -55,9 +55,9 @@
                                  <content>
                                     <AnchorPane fx:id="outdoorsZoomWrapper">
                                        <children>
-                                          <AnchorPane fx:id="outdoorsEditingFloor" minHeight="0.0" minWidth="0.0">
+                                          <AnchorPane fx:id="outdoorsEditingFloor" minHeight="3600.0" minWidth="3436.0">
                                              <children>
-                                                <ImageView fx:id="outdoorsFloorImage" fitHeight="1485.0" fitWidth="2475.0" mouseTransparent="false" pickOnBounds="true" preserveRatio="true" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                                <ImageView fx:id="outdoorsFloorImage" fitHeight="3600.0" fitWidth="3436.0" mouseTransparent="false" pickOnBounds="true" preserveRatio="true" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="0.0">
                                                    <image>
                                                       <Image url="@../NewFloors/outsideFloor.png" />
                                                    </image>
@@ -79,9 +79,9 @@
                                  <content>
                                     <AnchorPane fx:id="belkinZoomWrapper">
                                        <children>
-                                          <AnchorPane fx:id="belkinEditingFloor" minHeight="0.0" minWidth="0.0">
+                                          <AnchorPane fx:id="belkinEditingFloor" minHeight="643.0" minWidth="563.0">
                                              <children>
-                                                <ImageView fx:id="belkinFloorImage" fitHeight="1485.0" fitWidth="2475.0" mouseTransparent="false" pickOnBounds="true" preserveRatio="true" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                                <ImageView fx:id="belkinFloorImage" fitHeight="643.0" fitWidth="563.0" mouseTransparent="false" pickOnBounds="true" preserveRatio="true" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="0.0">
                                                    <image>
                                                       <Image url="@../NewFloors/belkin1rsz.png" />
                                                    </image>

--- a/src/main/resources/fxml/MapEditorTool.fxml
+++ b/src/main/resources/fxml/MapEditorTool.fxml
@@ -1,23 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import java.lang.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.image.*?>
-<?import javafx.scene.layout.*?>
-<?import javafx.scene.text.*?>
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ChoiceBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.Separator?>
 <?import javafx.scene.control.TextField?>
-<?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="720.0" prefWidth="1280.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="ui.controller.MapEditorToolController">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="720.0" prefWidth="1280.0" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="ui.controller.MapEditorToolController">
    <children>
       <HBox AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
          <children>
@@ -25,15 +22,11 @@
                <children>
                   <ScrollPane fx:id="mainScroll" hbarPolicy="ALWAYS" pannable="true" vbarPolicy="ALWAYS">
                      <content>
-                        <AnchorPane fx:id="zoomWrapper">
+                        <AnchorPane fx:id="zoomWrapper" minHeight="0.0" minWidth="0.0">
                            <children>
                               <AnchorPane fx:id="editingFloor" minHeight="0.0" minWidth="0.0" onMouseMoved="#redrawCanvas">
                                  <children>
-                                    <ImageView fx:id="floorImage" fitHeight="1300.0" fitWidth="2250.0" onMouseClicked="#clickFloorImage" onMouseDragged="#displayContextMenu" onMouseReleased="#releaseMouse" pickOnBounds="true" preserveRatio="true" AnchorPane.leftAnchor="0.0" AnchorPane.topAnchor="0.0">
-                                       <image>
-                                          <Image url="@../images/floor3.png" />
-                                       </image>
-                                    </ImageView>
+                                    <ImageView fx:id="floorImage" fitHeight="100.0" fitWidth="100.0" onMouseClicked="#clickFloorImage" onMouseDragged="#displayContextMenu" onMouseReleased="#releaseMouse" pickOnBounds="true" preserveRatio="true" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" />
                                  </children>
                               </AnchorPane>
                            </children>


### PR DESCRIPTION
Refactored so that the visitor side map has better layout and now uses tabs.
Understanding how the code works is nearly unchanged from before, except for changing tabs instead of images when going between buildings. 

I've also cleaned up some of the spaghetti and added some comment sauce.

With our hard-coded data, the current map will look weird. If you want to be able to properly see shit, go into the map editor and move around nodes before checking out the visitor map (especially belkin... all the places nodes are out of the viewable area with the new setup). 
I'll have to think about whether this will be solved by scaling a bunch of shit or delegating the work to datamonkeys.